### PR TITLE
Python 3 support

### DIFF
--- a/celery_unique.py
+++ b/celery_unique.py
@@ -173,5 +173,4 @@ def unique_task_factory(task_cls):
     @return: The new Celery task base class with unique task-handling functionality mixed in.
     @rtype: type
     """
-    name = b'UniqueTask' if six.PY2 else 'UniqueTask'
-    return type(name, (UniqueTaskMixin, task_cls), {})
+    return type(str('UniqueTask'), (UniqueTaskMixin, task_cls), {})

--- a/celery_unique.py
+++ b/celery_unique.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 
 import datetime
 
+import six
+
 
 UNIQUE_REDIS_KEY_PREFIX = 'celery_unique'
 
@@ -171,4 +173,5 @@ def unique_task_factory(task_cls):
     @return: The new Celery task base class with unique task-handling functionality mixed in.
     @rtype: type
     """
-    return type(b'UniqueTask', (UniqueTaskMixin, task_cls), {})
+    name = b'UniqueTask' if six.PY2 else 'UniqueTask'
+    return type(name, (UniqueTaskMixin, task_cls), {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+application-import-names=celery_unique,tests
+exclude=.tox,build
+import-order-style=smarkets
+max-line-length=120

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ application-import-names=celery_unique,tests
 exclude=.tox,build
 import-order-style=smarkets
 max-line-length=120
+
+[coverage:run]
+source = celery_unique

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,12 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Object Brokering',
         'Topic :: Software Development :: Distributed Computing'
     ]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,5 +8,5 @@ from celery.result import AsyncResult
 
 
 class SimpleFakeTaskBase(object):
-    def apply_async(self, args=None, kwargs=None, task_id=None, producer=None, link=None, link_error=None, **options):
+    def apply_async(self, *args, **kwargs):
         return AsyncResult(str(uuid4()))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import datetime
 from uuid import uuid4
 
 from celery.result import AsyncResult
@@ -11,32 +10,3 @@ from celery.result import AsyncResult
 class SimpleFakeTaskBase(object):
     def apply_async(self, args=None, kwargs=None, task_id=None, producer=None, link=None, link_error=None, **options):
         return AsyncResult(str(uuid4()))
-
-
-def make_frozen_datetime(freeze_point):
-    """Produces a subclass of `datetime.datetime` where the `now()` method always returns the same, known value.
-
-    @note This is a bit of a monstrosity, but it serves a useful purpose here when we mock the `datetime` module
-    for a specific target which, in addition to calling `datetime.datetime.now()`, will also be calling
-    `isinstance(something, datetime.datetime)`.  The usual mocked approach causes a failure since, within the
-    patched context, `datetime.datetime` is an *instance* of `mock.Mock`, whereas Python requires that the
-    second argument to `isinstance()` must be a class, type, or tuple of classes and types.
-
-    @param freeze_point: The value that the should always be returned when the `now()` method is called on the
-        class returned by this factory function.  This could be anything, although it should probably be
-        an instance of `datetime.datetime`.
-
-    @return: A new subclass of `datetime.datetime` whose `now()` method will always return the value provided by
-        the `freeze_point` argument (or specifically, the value of its `_now_constant` class variable.
-    @rtype: type
-    """
-    MetaDatetime = type(
-        b'MetaDatetime',
-        (type,),
-        {
-            '__instancecheck__': (lambda c, o: isinstance(o, datetime.datetime)),
-            '_now_constant': freeze_point
-        }
-    )
-    OverrideDatetime = type(b'datetime', (datetime.datetime,), {'now': classmethod(lambda cls, tz: cls._now_constant)})
-    return MetaDatetime(b'datetime', (OverrideDatetime,), {})

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -5,13 +5,13 @@ from __future__ import unicode_literals
 import datetime
 import inspect
 import unittest
-from uuid import uuid4
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
+from celery import uuid
 from celery.result import AsyncResult
 from freezegun import freeze_time
 from mockredis import mock_redis_client
@@ -90,7 +90,7 @@ class UniqueTaskMixinRevokeExtantUniqueTaskIfExistsTestCase(UniqueTaskMixinTestC
         self.assertFalse(mock_redis_client_delete.called)
 
     def test_revokes_async_result_when_found_in_redis(self):
-        test_task_id = uuid4().hex.encode()
+        test_task_id = uuid().encode()
         self.test_instance.redis_client.set(self.test_unique_task_key, test_task_id)
         self.assertEqual(self.test_instance.redis_client.get(self.test_unique_task_key), test_task_id)
         self.test_instance._revoke_extant_unique_task_if_exists(self.test_unique_task_key)
@@ -98,7 +98,7 @@ class UniqueTaskMixinRevokeExtantUniqueTaskIfExistsTestCase(UniqueTaskMixinTestC
         self.assertIsNone(self.mock_async_result.revoke.assert_called_once_with())
 
     def test_deletes_from_redis_when_found_in_redis(self):
-        test_task_id = uuid4().hex.encode()
+        test_task_id = uuid().encode()
         self.test_instance.redis_client.set(self.test_unique_task_key, test_task_id)
         self.assertIsNotNone(self.test_instance.redis_client.get(self.test_unique_task_key))
         self.assertEqual(self.test_instance.redis_client.get(self.test_unique_task_key), test_task_id)
@@ -115,7 +115,7 @@ class UniqueTaskMixinCreateUniqueTaskRecordTestCase(UniqueTaskMixinTestCase):
         self.assertIsNone(self.test_instance.redis_client.get(self.test_unique_task_key))
 
     def test_redis_record_created(self):
-        test_task_id = uuid4().hex.encode()
+        test_task_id = uuid().encode()
         test_ttl_seconds = 10
         self.test_instance._create_unique_task_record(self.test_unique_task_key, test_task_id, test_ttl_seconds)
         redis_value = self.test_instance.redis_client.get(self.test_unique_task_key)
@@ -125,7 +125,7 @@ class UniqueTaskMixinCreateUniqueTaskRecordTestCase(UniqueTaskMixinTestCase):
         self.assertLessEqual(redis_record_ttl, test_ttl_seconds)
 
     def test_redis_set_method_called_with_expected_arguments(self):
-        test_task_id = uuid4().hex.encode()
+        test_task_id = uuid().encode()
         test_ttl_seconds = 10
         with mock.patch.object(self.test_instance.redis_client, 'set') as mock_redis_client_set:
             self.test_instance._create_unique_task_record(self.test_unique_task_key, test_task_id, test_ttl_seconds)
@@ -299,7 +299,7 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
         self.assertIsNone(mock_redis_client_get.assert_called_once_with(self.test_unique_redis_key))
 
     def test_revokes_extant_task_when_one_exists(self):
-        test_extant_tracked_task_id = uuid4().hex.encode()
+        test_extant_tracked_task_id = uuid().encode()
         self.assertIsNotNone(test_extant_tracked_task_id)
         self.redis_client.set(self.test_unique_redis_key, test_extant_tracked_task_id)
         self.assertEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
@@ -316,7 +316,7 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
         self.assertNotEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
 
     def test_creates_new_task_record_when_extant_task_exists(self):
-        test_extant_tracked_task_id = uuid4().hex.encode()
+        test_extant_tracked_task_id = uuid().encode()
         self.assertIsNotNone(test_extant_tracked_task_id)
         self.redis_client.set(self.test_unique_redis_key, test_extant_tracked_task_id)
         self.assertEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -7,7 +7,11 @@ import inspect
 import unittest
 from uuid import uuid4
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from celery.result import AsyncResult
 from freezegun import freeze_time
 from mockredis import mock_redis_client

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -4,16 +4,14 @@ from __future__ import unicode_literals
 
 import datetime
 import inspect
-import pytz
 import unittest
 from uuid import uuid4
 
-from celery.result import AsyncResult
 import mock
+from celery.result import AsyncResult
 from mockredis import mock_redis_client
 
 import celery_unique
-
 from tests import helpers
 
 

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -143,7 +143,6 @@ class UniqueTaskMixinMakeTTLForUniqueTaskRecordTestCase(UniqueTaskMixinTestCase)
         self.assertEqual(actual_ttl, expected_ttl)
 
     def test_ttl_is_difference_between_now_and_eta_if_eta_in_task_options_without_expiry_can_be_timezone_aware(self):
-        eastern_timezone = pytz.timezone('US/Eastern')
         test_current_datetime_now_value = datetime.datetime.now()
         test_task_options = {'eta': test_current_datetime_now_value + datetime.timedelta(days=1)}
         expected_ttl = int((test_task_options['eta'] - test_current_datetime_now_value).total_seconds())

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -86,7 +86,7 @@ class UniqueTaskMixinRevokeExtantUniqueTaskIfExistsTestCase(UniqueTaskMixinTestC
         self.assertFalse(mock_redis_client_delete.called)
 
     def test_revokes_async_result_when_found_in_redis(self):
-        test_task_id = str(uuid4())
+        test_task_id = uuid4().hex.encode()
         self.test_instance.redis_client.set(self.test_unique_task_key, test_task_id)
         self.assertEqual(self.test_instance.redis_client.get(self.test_unique_task_key), test_task_id)
         self.test_instance._revoke_extant_unique_task_if_exists(self.test_unique_task_key)
@@ -94,7 +94,7 @@ class UniqueTaskMixinRevokeExtantUniqueTaskIfExistsTestCase(UniqueTaskMixinTestC
         self.assertIsNone(self.mock_async_result.revoke.assert_called_once_with())
 
     def test_deletes_from_redis_when_found_in_redis(self):
-        test_task_id = str(uuid4())
+        test_task_id = uuid4().hex.encode()
         self.test_instance.redis_client.set(self.test_unique_task_key, test_task_id)
         self.assertIsNotNone(self.test_instance.redis_client.get(self.test_unique_task_key))
         self.assertEqual(self.test_instance.redis_client.get(self.test_unique_task_key), test_task_id)
@@ -111,7 +111,7 @@ class UniqueTaskMixinCreateUniqueTaskRecordTestCase(UniqueTaskMixinTestCase):
         self.assertIsNone(self.test_instance.redis_client.get(self.test_unique_task_key))
 
     def test_redis_record_created(self):
-        test_task_id = str(uuid4())
+        test_task_id = uuid4().hex.encode()
         test_ttl_seconds = 10
         self.test_instance._create_unique_task_record(self.test_unique_task_key, test_task_id, test_ttl_seconds)
         redis_value = self.test_instance.redis_client.get(self.test_unique_task_key)
@@ -121,7 +121,7 @@ class UniqueTaskMixinCreateUniqueTaskRecordTestCase(UniqueTaskMixinTestCase):
         self.assertLessEqual(redis_record_ttl, test_ttl_seconds)
 
     def test_redis_set_method_called_with_expected_arguments(self):
-        test_task_id = str(uuid4())
+        test_task_id = uuid4().hex.encode()
         test_ttl_seconds = 10
         with mock.patch.object(self.test_instance.redis_client, 'set') as mock_redis_client_set:
             self.test_instance._create_unique_task_record(self.test_unique_task_key, test_task_id, test_ttl_seconds)
@@ -295,7 +295,7 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
         self.assertIsNone(mock_redis_client_get.assert_called_once_with(self.test_unique_redis_key))
 
     def test_revokes_extant_task_when_one_exists(self):
-        test_extant_tracked_task_id = str(uuid4())
+        test_extant_tracked_task_id = uuid4().hex.encode()
         self.assertIsNotNone(test_extant_tracked_task_id)
         self.redis_client.set(self.test_unique_redis_key, test_extant_tracked_task_id)
         self.assertEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
@@ -312,7 +312,7 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
         self.assertNotEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
 
     def test_creates_new_task_record_when_extant_task_exists(self):
-        test_extant_tracked_task_id = str(uuid4())
+        test_extant_tracked_task_id = uuid4().hex.encode()
         self.assertIsNotNone(test_extant_tracked_task_id)
         self.redis_client.set(self.test_unique_redis_key, test_extant_tracked_task_id)
         self.assertEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
@@ -327,7 +327,7 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
         )
         self.assertIsInstance(rs, AsyncResult)
         self.assertNotEqual(self.redis_client.get(self.test_unique_redis_key), test_extant_tracked_task_id)
-        self.assertEqual(self.redis_client.get(self.test_unique_redis_key), rs.task_id)
+        self.assertEqual(self.redis_client.get(self.test_unique_redis_key), rs.task_id.encode())
 
     def test_creates_new_task_record_when_no_extant_task_exists(self):
         self.assertIsNone(self.redis_client.get(self.test_unique_redis_key))
@@ -341,4 +341,4 @@ class UniqueTaskMixinApplyAsyncTestCase(UniqueTaskMixinTestCase):
             countdown=100
         )
         self.assertIsInstance(rs, AsyncResult)
-        self.assertEqual(self.redis_client.get(self.test_unique_redis_key), rs.task_id)
+        self.assertEqual(self.redis_client.get(self.test_unique_redis_key), rs.task_id.encode())

--- a/tests/test_celery_unique.py
+++ b/tests/test_celery_unique.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import mock
 from celery.result import AsyncResult
+from freezegun import freeze_time
 from mockredis import mock_redis_client
 
 import celery_unique
@@ -187,6 +188,7 @@ class UniqueTaskMixinMakeTTLForUniqueTaskRecordTestCase(UniqueTaskMixinTestCase)
         actual_ttl = celery_unique.UniqueTaskMixin._make_ttl_for_unique_task_record(test_task_options)
         self.assertEqual(expected_ttl, actual_ttl)
 
+    @freeze_time('2017-04-28')
     def test_datetime_expires_in_task_options_overrides_ttl_if_expiry_time_is_less_than_ttl(self):
         test_current_datetime_now_value = datetime.datetime.now()
         test_seconds_to_expiry = 50
@@ -199,11 +201,10 @@ class UniqueTaskMixinMakeTTLForUniqueTaskRecordTestCase(UniqueTaskMixinTestCase)
             test_task_options['countdown']
         )
         expected_ttl = test_seconds_to_expiry
-        with mock.patch.object(celery_unique, 'datetime', mock.Mock(wraps=datetime)) as mocked_datetime:
-            mocked_datetime.datetime = helpers.make_frozen_datetime(test_current_datetime_now_value)
-            actual_ttl = celery_unique.UniqueTaskMixin._make_ttl_for_unique_task_record(test_task_options)
+        actual_ttl = celery_unique.UniqueTaskMixin._make_ttl_for_unique_task_record(test_task_options)
         self.assertEqual(expected_ttl, actual_ttl)
 
+    @freeze_time('2017-04-28')
     def test_datetime_expires_in_task_options_does_not_override_ttl_if_expiry_time_is_greater_than_ttl(self):
         test_current_datetime_now_value = datetime.datetime.now()
         test_seconds_to_expiry = 100
@@ -216,9 +217,7 @@ class UniqueTaskMixinMakeTTLForUniqueTaskRecordTestCase(UniqueTaskMixinTestCase)
             test_task_options['countdown']
         )
         expected_ttl = test_task_options['countdown']
-        with mock.patch.object(celery_unique, 'datetime', mock.Mock(wraps=datetime)) as mocked_datetime:
-            mocked_datetime.datetime = helpers.make_frozen_datetime(test_current_datetime_now_value)
-            actual_ttl = celery_unique.UniqueTaskMixin._make_ttl_for_unique_task_record(test_task_options)
+        actual_ttl = celery_unique.UniqueTaskMixin._make_ttl_for_unique_task_record(test_task_options)
         self.assertEqual(expected_ttl, actual_ttl)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27, py33, py34, py35, py36, pypy3, flake8
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+  -rrequirements.txt
+  freezegun
+commands = python setup.py test
+
+[testenv:flake8]
+basepython = python3
+skip_install = True
+deps =
+  flake8
+  flake8-import-order
+commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ skip_missing_interpreters = True
 [testenv]
 deps =
   -rrequirements.txt
+  coverage
   freezegun
-commands = python setup.py test
+commands = coverage run -m unittest
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   -rrequirements.txt
   coverage
   freezegun
-commands = coverage run -m unittest
+commands = coverage run -m unittest discover
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
Add python3 support.

* Some minor unicode/bytes tweaks on tests.
* Dropped `make_frozen_datetime` in favour of `freezegun`, which does all the heavy work for us (the former didn't work on py3, and I didn't think it worth fixing if we have this solved for us).
* Add `tox` to quickly run tests on all supported pythons, and style checks.